### PR TITLE
using relative imports so the project can compile when imported as an npm module

### DIFF
--- a/contracts/ERC721CM.sol
+++ b/contracts/ERC721CM.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-import "contracts/creator-token-standards/ERC721ACQueryable.sol";
+import "./creator-token-standards/ERC721ACQueryable.sol";
 import "./IERC721M.sol";
 import "./utils/Constants.sol";
 

--- a/contracts/ERC721CMInitializable.sol
+++ b/contracts/ERC721CMInitializable.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "contracts/creator-token-standards/ERC721ACQueryableInitializable.sol";
+import "./creator-token-standards/ERC721ACQueryableInitializable.sol";
 import "./access/OwnableInitializable.sol";
 import "./IERC721MInitializable.sol";
 import "./utils/Constants.sol";


### PR DESCRIPTION
Hi there,

When creating a new project with Hardhat, and adding magicdrop npm module with `npm add @magiceden-oss/erc721m`, the project doesn't compile because of some absolute imports of Solidity files from the `contracts` folder.

This PR only replaces those imports with relative ones (like done for the other imports), then the project compiles :)

Thanks guys!