### PR TITLE
Set sideEffects:false in package.json

### DIFF
--- a/cosign-server/package.json
+++ b/cosign-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cosign-server",
   "version": "0.0.3",
+  "sideEffects": false,
   "devDependencies": {
     "@cloudflare/workers-types": "^3.16.0",
     "typescript": "^4.8.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
+  "sideEffects": false,
   "scripts": {
     "node": "hardhat node",
     "build": "npm run build:contracts && npm run build:typescript",
@@ -92,8 +93,6 @@
       "eslint --ext .ts,.js scripts test --fix",
       "prettier --write scripts cosign-server test hardhat.config.ts"
     ],
-    "*.sol": [
-      "prettier --write --plugin=prettier-plugin-solidity contracts"
-    ]
+    "*.sol": ["prettier --write --plugin=prettier-plugin-solidity contracts"]
   }
 }


### PR DESCRIPTION

![Screenshot 2024-08-01 at 4 34 01 PM](https://github.com/user-attachments/assets/26caf9cb-9eae-4e11-b0e3-5ddc63bff466)


As proved in https://github.com/magiceden/magiceden/pull/28032, setting `sideEffects:false` in this package will have less of a bundle size impact in consuming packages. 

![Screenshot 2024-08-01 at 4 34 29 PM](https://github.com/user-attachments/assets/f9592b39-a760-43fd-abd6-f370f34a7bd4)




Read more about `sideEffects`: https://webpack.js.org/guides/tree-shaking/