### PR TITLE
[Reservoir Relay] Change default authorizedMinter address from EOA to router

### DIFF
--- a/scripts/common/constants.ts
+++ b/scripts/common/constants.ts
@@ -22,4 +22,4 @@ export const ERC721CV2_EMPTY_LIST = 4;
 // Mainnet, Polygon, Base
 export const ERC721CMRoyaltiesCloneFactoryContract = '0x7cEEd7215D71393d56966dA48C5727851326e101';
 
-export const RESERVOIR_RELAYER_EOA = '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF';
+export const RESERVOIR_RELAYER_ROUTER = '0x2f5d6b76bf8086797e1bd0b28bb4dd5583476cc9';

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,7 +6,7 @@
 
 import { confirm } from '@inquirer/prompts';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { ContractDetails, RESERVOIR_RELAYER_EOA } from './common/constants';
+import { ContractDetails, RESERVOIR_RELAYER_ROUTER } from './common/constants';
 import { checkCodeVersion, estimateGas } from './utils/helper';
 import { Overrides } from 'ethers';
 
@@ -140,6 +140,6 @@ export const deploy = async (
   );
 
   const erc721cm = ERC721CM.attach(contract.address);
-  await erc721cm.addAuthorizedMinter(RESERVOIR_RELAYER_EOA);
+  await erc721cm.addAuthorizedMinter(RESERVOIR_RELAYER_ROUTER);
   console.log('[ERC721CM] Added Reservoir Relayer as authorized minter');
 };

--- a/scripts/deploy1155.ts
+++ b/scripts/deploy1155.ts
@@ -1,6 +1,6 @@
 import { confirm } from '@inquirer/prompts';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { ContractDetails, RESERVOIR_RELAYER_EOA } from './common/constants';
+import { ContractDetails, RESERVOIR_RELAYER_ROUTER } from './common/constants';
 import { checkCodeVersion, estimateGas } from './utils/helper';
 import { Overrides } from 'ethers';
 
@@ -103,6 +103,6 @@ export const deploy1155 = async (
   );
 
   // Add reservoir relay as authorized minter by default
-  await contract.addAuthorizedMinter(RESERVOIR_RELAYER_EOA);
+  await contract.addAuthorizedMinter(RESERVOIR_RELAYER_ROUTER);
   console.log('[ERC721CM] Added Reservoir Relayer as authorized minter');
 };


### PR DESCRIPTION
Relay mints tokens from the router not the EOA. Meaning, the router address needs access to `authorizedMint` instead.

Ref: https://magiceden.slack.com/archives/C04UWH6JQF8/p1724331599480059?thread_ts=1724192746.048759&cid=C04UWH6JQF8

Note: `0x2f5d6b76bf8086797e1bd0b28bb4dd5583476cc9` is a new version of the Relay router and is not yet deployed to any other network than Base. It is also not yet verified. 