### PR TITLE
Update scripts for set stages to handle multiple ids for 1155 mints

### DIFF
--- a/scripts/utils/helper.ts
+++ b/scripts/utils/helper.ts
@@ -205,3 +205,5 @@ export const cleanWhitelist = async (whitelistPath: string, writeToFile: boolean
   console.log(`=========================================`);
   return wallets;
 }
+
+export const ensureArray = (value: any) => Array.isArray(value) ? value : [value];


### PR DESCRIPTION
`set1155Stages.ts` was previously only compatible with single-edition 1155 mints. This PR adds the handling for multiple token ids while keeping the script backwards compatible.

Note: source of truth for editions is the `price` field. 3 elements in price field means there are 3 editions.