### PR TITLE
Add cosigner in 1155M

### DIFF
--- a/contracts/IERC1155M.sol
+++ b/contracts/IERC1155M.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.8.20;
 
 interface IERC1155M {
     error CannotIncreaseMaxMintableSupply();
+    error CosignerNotSet();
     error NewSupplyLessThanTotalSupply();
     error GlobalWalletLimitOverflow();
     error InsufficientStageTimeGap();
+    error InvalidCosignSignature();
     error InvalidLimitArgsLength();
     error InvalidProof();
     error InvalidStage();
@@ -46,6 +48,8 @@ interface IERC1155M {
         uint64 startTimeUnixSeconds,
         uint64 endTimeUnixSeconds
     );
+
+    event SetCosigner(address cosigner);
     event SetMaxMintableSupply(uint256 indexed tokenId, uint256 maxMintableSupply);
     event SetGlobalWalletLimit(uint256 indexed tokenId, uint256 globalWalletLimit);
     event Withdraw(uint256 value);
@@ -67,14 +71,18 @@ interface IERC1155M {
     function mint(
         uint256 tokenId,
         uint32 qty,
-        bytes32[] calldata proof
+        bytes32[] calldata proof,
+        uint64 timestamp,
+        bytes calldata signature
     ) external payable;
 
     function mintWithLimit(
         uint256 tokenId,
         uint32 qty,
         uint32 limit,
-        bytes32[] calldata proof
+        bytes32[] calldata proof,
+        uint64 timestamp,
+        bytes calldata signature
     ) external payable;
 
     function authorizedMint(

--- a/contracts/mocks/ERC1155MTestReentrantExploit.sol
+++ b/contracts/mocks/ERC1155MTestReentrantExploit.sol
@@ -19,7 +19,9 @@ contract ERC1155MTestReentrantExploit {
         ERC1155M(_targetContract).mint{value: msg.value}(
             tokenId,
             qty,
-            proof
+            proof,
+            0,
+            bytes("0")
         );
     }
 
@@ -31,7 +33,13 @@ contract ERC1155MTestReentrantExploit {
         bytes calldata data
     ) public payable returns (bytes4) {
         bytes32[] memory proof;
-        ERC1155M(_targetContract).mint{value: msg.value}(0, 1, proof);
+        ERC1155M(_targetContract).mint{value: msg.value}(
+            0,
+            1,
+            proof,
+            0,
+            bytes("0")
+        );
         return IERC1155Receiver.onERC1155Received.selector;
     }
 }


### PR DESCRIPTION
- Add cosigner into 1155M, similar to 721M
- Signed signature:
 ```
  keccak256(
      abi.encodePacked(
          address(this),
          minter,
          qty,
          _cosigner,
          timestamp,
          block.chainid,
          getCosignNonce(minter, tokenId)
      )
  )
 ```