### PR TITLE
add ERC721ACloneable interface

### DIFF
--- a/contracts/nft/erc721m/ERC721MInitializableV1_0_1.sol
+++ b/contracts/nft/erc721m/ERC721MInitializableV1_0_1.sol
@@ -297,7 +297,8 @@ contract ERC721MInitializableV1_0_1 is
         override(ERC2981, ERC721ACloneable, IERC721A)
         returns (bool)
     {
-        return super.supportsInterface(interfaceId) || ERC2981.supportsInterface(interfaceId);
+        return super.supportsInterface(interfaceId) || ERC2981.supportsInterface(interfaceId)
+            || ERC721ACloneable.supportsInterface(interfaceId);
     }
 
     /*==============================================================


### PR DESCRIPTION
When super.supportsInterface() is called in `ERC721MInitializableV1_0_1`, it only looks at the immediate parent's implementation `ERC721AConduitPreapprovedCloneable`. Since that contract and `ERC721AQueryableCloneable` don't override supportsInterface, the call doesn't properly traverse up to `ERC721ACloneable`'s implementation.