### PR TITLE
[Scripts] Deploy implementations direct

### DIFF
--- a/contracts/nft/erc721m/ERC721CM.sol
+++ b/contracts/nft/erc721m/ERC721CM.sol
@@ -54,8 +54,11 @@ contract ERC721CM is
         uint256 timestampExpirySeconds,
         address mintCurrency,
         address fundReceiver,
-        uint256 mintFee
-    ) ERC721ACQueryable(collectionName, collectionSymbol) Ownable() {
+        uint256 mintFee,
+        address initialOwner
+    ) ERC721ACQueryable(collectionName, collectionSymbol) {
+        _transferOwnership(initialOwner);
+
         if (globalWalletLimit > maxMintableSupply) {
             revert GlobalWalletLimitOverflow();
         }

--- a/scripts-foundry/common/100a-create2-magicdrop-impl.sh
+++ b/scripts-foundry/common/100a-create2-magicdrop-impl.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+if [ -f .env ]
+then
+  export $(grep -v '^#' .env | xargs)
+else
+    echo "Please set your .env file"
+    exit 1
+fi
+
+NAME=""
+SYMBOL=""
+TOKEN_URI_SUFFIX=""
+MAX_MINTABLE_SUPPLY="1000"
+GLOBAL_WALLET_LIMIT="0"
+COSIGNER="0x0000000000000000000000000000000000000000"
+TIMESTAMP_EXPIRY_SECONDS="60"
+MINT_CURRENCY="0x0000000000000000000000000000000000000000"
+FUND_RECEIVER=""
+MINT_FEE="0"
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 --impl <path to implementation> --name <name> --symbol <symbol> --fund-receiver <fund receiver address> --mint-fee <mint fee>"
+    exit 1
+}
+
+# Process arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --impl) IMPL_PATH=$2; shift ;;
+        --name) NAME=$2; shift ;;
+        --symbol) SYMBOL=$2; shift ;;
+        --fund-receiver) FUND_RECEIVER=$2; shift ;;
+        --mint-fee) MINT_FEE=$2; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+echo "IMPL_PATH: $IMPL_PATH"
+echo "NAME: $NAME"
+echo "SYMBOL: $SYMBOL"
+echo "FUND_RECEIVER: $FUND_RECEIVER"
+echo "MINT_FEE: $MINT_FEE"
+
+# Check if all parameters are set
+if [ -z "$IMPL_PATH" ] || [ -z "$NAME" ] || [ -z "$SYMBOL" ] || [ -z "$FUND_RECEIVER" ] || [ -z "$MINT_FEE" ]; then
+    usage
+fi
+
+# NOTE: If you change the number of optimizer runs, you must also change the number in the deploy script, otherwise the CREATE2 address will be different
+
+echo "create2 MagicDropImpl START"
+
+implByteCode="$(forge inspect contracts/nft/erc721m/ERC721CM.sol:ERC721CM bytecode --optimizer-runs 777 --via-ir)"
+constructorArgs=$(cast abi-encode "constructor(string,string,string,uint256,uint256,address,uint256,address,address,uint256)" "$NAME" "$SYMBOL" "$TOKEN_URI_SUFFIX" "$MAX_MINTABLE_SUPPLY" "$GLOBAL_WALLET_LIMIT" "$COSIGNER" "$TIMESTAMP_EXPIRY_SECONDS" "$MINT_CURRENCY" "$FUND_RECEIVER" "$MINT_FEE")
+constructorArgsNoPrefix=${constructorArgs#0x}
+implInitCode=$(cast concat-hex $implByteCode $constructorArgsNoPrefix)
+
+cast create2 --starts-with 88888888 --case-sensitive --init-code $implInitCode
+echo "create2 MagicDropImpl END"
+echo "-------------------------------------"
+echo ""

--- a/scripts-foundry/common/100a-create2-magicdrop-impl.sh
+++ b/scripts-foundry/common/100a-create2-magicdrop-impl.sh
@@ -18,10 +18,11 @@ TIMESTAMP_EXPIRY_SECONDS="60"
 MINT_CURRENCY="0x0000000000000000000000000000000000000000"
 FUND_RECEIVER=""
 MINT_FEE="0"
+INITIAL_OWNER=""
 
 # Function to display usage
 usage() {
-    echo "Usage: $0 --impl <path to implementation> --name <name> --symbol <symbol> --fund-receiver <fund receiver address> --mint-fee <mint fee>"
+    echo "Usage: $0 --impl <path to implementation> --name <name> --symbol <symbol> --fund-receiver <fund receiver address> --mint-fee <mint fee> --initial-owner <initial owner address>"
     exit 1
 }
 
@@ -33,6 +34,7 @@ while [[ "$#" -gt 0 ]]; do
         --symbol) SYMBOL=$2; shift ;;
         --fund-receiver) FUND_RECEIVER=$2; shift ;;
         --mint-fee) MINT_FEE=$2; shift ;;
+        --initial-owner) INITIAL_OWNER=$2; shift ;;
         *) usage ;;
     esac
     shift
@@ -43,9 +45,10 @@ echo "NAME: $NAME"
 echo "SYMBOL: $SYMBOL"
 echo "FUND_RECEIVER: $FUND_RECEIVER"
 echo "MINT_FEE: $MINT_FEE"
+echo "INITIAL_OWNER: $INITIAL_OWNER"
 
 # Check if all parameters are set
-if [ -z "$IMPL_PATH" ] || [ -z "$NAME" ] || [ -z "$SYMBOL" ] || [ -z "$FUND_RECEIVER" ] || [ -z "$MINT_FEE" ]; then
+if [ -z "$IMPL_PATH" ] || [ -z "$NAME" ] || [ -z "$SYMBOL" ] || [ -z "$FUND_RECEIVER" ] || [ -z "$MINT_FEE" ] || [ -z "$INITIAL_OWNER" ]; then
     usage
 fi
 
@@ -54,9 +57,11 @@ fi
 echo "create2 MagicDropImpl START"
 
 implByteCode="$(forge inspect contracts/nft/erc721m/ERC721CM.sol:ERC721CM bytecode --optimizer-runs 777 --via-ir)"
-constructorArgs=$(cast abi-encode "constructor(string,string,string,uint256,uint256,address,uint256,address,address,uint256)" "$NAME" "$SYMBOL" "$TOKEN_URI_SUFFIX" "$MAX_MINTABLE_SUPPLY" "$GLOBAL_WALLET_LIMIT" "$COSIGNER" "$TIMESTAMP_EXPIRY_SECONDS" "$MINT_CURRENCY" "$FUND_RECEIVER" "$MINT_FEE")
+constructorArgs=$(cast abi-encode "constructor(string,string,string,uint256,uint256,address,uint256,address,address,uint256,address)" "$NAME" "$SYMBOL" "$TOKEN_URI_SUFFIX" "$MAX_MINTABLE_SUPPLY" "$GLOBAL_WALLET_LIMIT" "$COSIGNER" "$TIMESTAMP_EXPIRY_SECONDS" "$MINT_CURRENCY" "$FUND_RECEIVER" "$MINT_FEE" "$INITIAL_OWNER")
 constructorArgsNoPrefix=${constructorArgs#0x}
 implInitCode=$(cast concat-hex $implByteCode $constructorArgsNoPrefix)
+
+echo $constructorArgs
 
 cast create2 --starts-with 88888888 --case-sensitive --init-code $implInitCode
 echo "create2 MagicDropImpl END"

--- a/scripts-foundry/common/101a-deploy-magicdrop-impl-direct.sh
+++ b/scripts-foundry/common/101a-deploy-magicdrop-impl-direct.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+if [ -f .env ]
+then
+  export $(grep -v '^#' .env | xargs)
+else
+    echo "Please set your .env file"
+    exit 1
+fi
+
+# Note: Update the contract in the deploy script if you want to deploy a different version. Default is 1_0_0
+
+source ./utils
+
+# Exit on error
+set -e
+
+# Initialize variables with environment values
+CHAIN_ID=${CHAIN_ID:-""}
+RPC_URL=""
+STANDARD=""
+IS_ERC721C=false #optional
+IMPL_EXPECTED_ADDRESS=""
+IMPL_SALT=""
+NAME=""
+SYMBOL=""
+FUND_RECEIVER=""
+MINT_FEE=0
+
+# Function to display usage
+usage() {
+    # Example Usage: ./2a-deploy-magicdrop-impl.sh --chain-id 137 --token-standard ERC721 --is-erc721c true --expected-address 0x0000000000000000000000000000000000000000 --salt 0x0000000000000000000000000000000000000000000000000000000000000000
+    echo "Usage: $0 --chain-id <chain id> --token-standard <token standard> --is-erc721c <bool> --expected-address <expected address> --salt <salt> --name <name> --symbol <symbol> --fund-receiver <fund receiver address> --mint-fee <mint fee>"
+    exit 1
+}
+
+# Process arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --chain-id) CHAIN_ID=$2; shift ;;
+        --token-standard) STANDARD=$2; shift ;;
+        --is-erc721c) IS_ERC721C=$2; shift ;;
+        --expected-address) IMPL_EXPECTED_ADDRESS=$2; shift ;;
+        --salt) IMPL_SALT=$2; shift ;;
+        --name) NAME=$2; shift ;;
+        --symbol) SYMBOL=$2; shift ;;
+        --fund-receiver) FUND_RECEIVER=$2; shift ;;
+        --mint-fee) MINT_FEE=$2; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+# Check if all parameters are set
+if [ -z "$CHAIN_ID" ] || [ -z "$STANDARD" ] || [ -z "$IMPL_EXPECTED_ADDRESS" ] || [ -z "$IMPL_SALT" ] || [ -z "$NAME" ] || [ -z "$SYMBOL" ] || [ -z "$FUND_RECEIVER" ] || [ -z "$MINT_FEE" ]; then
+    usage
+fi
+
+# Set the RPC URL based on chain ID
+set_rpc_url $CHAIN_ID
+
+# Set the ETHERSCAN API KEY based on chain ID
+set_etherscan_api_key $CHAIN_ID
+
+# Convert STANDARD to lowercase for the path
+STANDARD_LOWERCASE=$(echo $STANDARD | tr '[:upper:]' '[:lower:]')
+
+echo ""
+echo "==================== DEPLOYMENT DETAILS ===================="
+echo "Chain ID:                     $CHAIN_ID"
+echo "RPC URL:                      $RPC_URL"
+echo "Token Standard:               $STANDARD"
+echo "Is ERC721C:                   $IS_ERC721C"
+echo "Expected Address:             $IMPL_EXPECTED_ADDRESS"
+echo "Salt:                         $IMPL_SALT"
+echo "Name:                         $NAME"
+echo "Symbol:                       $SYMBOL"
+echo "Fund Reciever:                $FUND_RECEIVER"
+echo "Mint Fee:                     $MINT_FEE"
+echo "============================================================"
+echo ""
+read -p "Do you want to proceed? (yes/no) " yn
+
+case $yn in 
+  yes ) echo ok, we will proceed;;
+  no ) echo exiting...;
+    exit;;
+  * ) echo invalid response;
+    exit 1;;
+esac
+
+echo ""
+echo "============= DEPLOYING MAGICDROP IMPLEMENTATION ============="
+echo ""
+
+# remove --verify when deploying on Sei Chain. You will need to verify manually.
+CHAIN_ID=$CHAIN_ID RPC_URL=$RPC_URL TOKEN_STANDARD=$STANDARD IS_ERC721C=$IS_ERC721C IMPL_EXPECTED_ADDRESS=$IMPL_EXPECTED_ADDRESS IMPL_SALT=$IMPL_SALT NAME=$NAME SYMBOL=$SYMBOL FUND_RECEIVER=$FUND_RECEIVER MINT_FEE=$MINT_FEE forge script ./DeployMagicDropImplementationDirect.s.sol:DeployMagicDropImplementationDirect \
+  --rpc-url $RPC_URL \
+  --broadcast \
+  --optimizer-runs 777 \
+  --via-ir \
+  --verify \
+  -v
+
+echo ""
+echo "============= DEPLOYED MAGICDROP IMPLEMENTATION ============="
+echo ""

--- a/scripts-foundry/common/101a-deploy-magicdrop-impl-direct.sh
+++ b/scripts-foundry/common/101a-deploy-magicdrop-impl-direct.sh
@@ -26,11 +26,12 @@ NAME=""
 SYMBOL=""
 FUND_RECEIVER=""
 MINT_FEE=0
+INITIAL_OWNER=""
 
 # Function to display usage
 usage() {
     # Example Usage: ./2a-deploy-magicdrop-impl.sh --chain-id 137 --token-standard ERC721 --is-erc721c true --expected-address 0x0000000000000000000000000000000000000000 --salt 0x0000000000000000000000000000000000000000000000000000000000000000
-    echo "Usage: $0 --chain-id <chain id> --token-standard <token standard> --is-erc721c <bool> --expected-address <expected address> --salt <salt> --name <name> --symbol <symbol> --fund-receiver <fund receiver address> --mint-fee <mint fee>"
+    echo "Usage: $0 --chain-id <chain id> --token-standard <token standard> --is-erc721c <bool> --expected-address <expected address> --salt <salt> --name <name> --symbol <symbol> --fund-receiver <fund receiver address> --mint-fee <mint fee> --initial-owner <initial owner>"
     exit 1
 }
 
@@ -46,13 +47,14 @@ while [[ "$#" -gt 0 ]]; do
         --symbol) SYMBOL=$2; shift ;;
         --fund-receiver) FUND_RECEIVER=$2; shift ;;
         --mint-fee) MINT_FEE=$2; shift ;;
+        --initial-owner) INITIAL_OWNER=$2; shift ;;
         *) usage ;;
     esac
     shift
 done
 
 # Check if all parameters are set
-if [ -z "$CHAIN_ID" ] || [ -z "$STANDARD" ] || [ -z "$IMPL_EXPECTED_ADDRESS" ] || [ -z "$IMPL_SALT" ] || [ -z "$NAME" ] || [ -z "$SYMBOL" ] || [ -z "$FUND_RECEIVER" ] || [ -z "$MINT_FEE" ]; then
+if [ -z "$CHAIN_ID" ] || [ -z "$STANDARD" ] || [ -z "$IMPL_EXPECTED_ADDRESS" ] || [ -z "$IMPL_SALT" ] || [ -z "$NAME" ] || [ -z "$SYMBOL" ] || [ -z "$FUND_RECEIVER" ] || [ -z "$MINT_FEE" ] || [ -z "$INITIAL_OWNER" ]; then
     usage
 fi
 
@@ -77,6 +79,7 @@ echo "Name:                         $NAME"
 echo "Symbol:                       $SYMBOL"
 echo "Fund Reciever:                $FUND_RECEIVER"
 echo "Mint Fee:                     $MINT_FEE"
+echo "Initial Owner:               $INITIAL_OWNER"
 echo "============================================================"
 echo ""
 read -p "Do you want to proceed? (yes/no) " yn
@@ -94,7 +97,7 @@ echo "============= DEPLOYING MAGICDROP IMPLEMENTATION ============="
 echo ""
 
 # remove --verify when deploying on Sei Chain. You will need to verify manually.
-CHAIN_ID=$CHAIN_ID RPC_URL=$RPC_URL TOKEN_STANDARD=$STANDARD IS_ERC721C=$IS_ERC721C IMPL_EXPECTED_ADDRESS=$IMPL_EXPECTED_ADDRESS IMPL_SALT=$IMPL_SALT NAME=$NAME SYMBOL=$SYMBOL FUND_RECEIVER=$FUND_RECEIVER MINT_FEE=$MINT_FEE forge script ./DeployMagicDropImplementationDirect.s.sol:DeployMagicDropImplementationDirect \
+CHAIN_ID=$CHAIN_ID RPC_URL=$RPC_URL TOKEN_STANDARD=$STANDARD IS_ERC721C=$IS_ERC721C IMPL_EXPECTED_ADDRESS=$IMPL_EXPECTED_ADDRESS IMPL_SALT=$IMPL_SALT NAME=$NAME SYMBOL=$SYMBOL FUND_RECEIVER=$FUND_RECEIVER MINT_FEE=$MINT_FEE INITIAL_OWNER=$INITIAL_OWNER forge script ./DeployMagicDropImplementationDirect.s.sol:DeployMagicDropImplementationDirect \
   --rpc-url $RPC_URL \
   --broadcast \
   --optimizer-runs 777 \

--- a/scripts-foundry/common/101a-deploy-magicdrop-impl-direct.sh
+++ b/scripts-foundry/common/101a-deploy-magicdrop-impl-direct.sh
@@ -100,6 +100,7 @@ CHAIN_ID=$CHAIN_ID RPC_URL=$RPC_URL TOKEN_STANDARD=$STANDARD IS_ERC721C=$IS_ERC7
   --optimizer-runs 777 \
   --via-ir \
   --verify \
+  --verifier custom \
   -v
 
 echo ""

--- a/scripts-foundry/common/DeployMagicDropImplementationDirect.s.sol
+++ b/scripts-foundry/common/DeployMagicDropImplementationDirect.s.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {Script, console} from "forge-std/Script.sol";
+import {ERC721M} from "contracts/nft/erc721m/ERC721M.sol";
+import {ERC721CM} from "contracts/nft/erc721m/ERC721CM.sol";
+import {ERC1155M} from "contracts/nft/erc1155m/ERC1155M.sol";
+import {TokenStandard} from "contracts/common/Structs.sol";
+
+contract DeployMagicDropImplementationDirect is Script {
+    error AddressMismatch(address expected, address actual);
+    error InvalidTokenStandard(string standard);
+    error NotImplementedYet();
+
+    function run() external {
+        bytes32 salt = vm.envBytes32("IMPL_SALT");
+        address expectedAddress = address(uint160(vm.envUint("IMPL_EXPECTED_ADDRESS")));
+        TokenStandard standard = parseTokenStandard(vm.envString("TOKEN_STANDARD"));
+        bool isERC721C = vm.envBool("IS_ERC721C");
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        string memory name = vm.envString("NAME");
+        string memory symbol = vm.envString("SYMBOL");
+        string memory tokenUriSuffix = "";
+        uint256 maxMintableSupply = 1000;
+        uint256 globalWalletLimit = 0;
+        address cosigner = address(0);
+        uint256 timestampExpirySeconds = 60;
+        address mintCurrency = address(0);
+        address fundReceiver = address(uint160(vm.envUint("FUND_RECEIVER")));
+        uint256 mintFee = vm.envUint("MINT_FEE");
+
+        vm.startBroadcast(privateKey);
+
+        address deployedAddress;
+
+        if (standard == TokenStandard.ERC721) {
+            if (isERC721C) {
+                deployedAddress = address(new ERC721CM{salt: salt}(
+                    name,
+                    symbol,
+                    tokenUriSuffix,
+                    maxMintableSupply,
+                    globalWalletLimit,
+                    cosigner,
+                    timestampExpirySeconds,
+                    mintCurrency,
+                    fundReceiver,
+                    mintFee
+                ));
+            } else {
+                revert NotImplementedYet();
+            }
+        } else if (standard == TokenStandard.ERC1155) {
+            revert NotImplementedYet();
+        }
+
+        if (address(deployedAddress) != expectedAddress) {
+            revert AddressMismatch(expectedAddress, deployedAddress);
+        }
+
+        vm.stopBroadcast();
+    }
+
+    function parseTokenStandard(string memory standardString) internal pure returns (TokenStandard) {
+        if (keccak256(abi.encodePacked(standardString)) == keccak256(abi.encodePacked("ERC721"))) {
+            return TokenStandard.ERC721;
+        } else if (keccak256(abi.encodePacked(standardString)) == keccak256(abi.encodePacked("ERC1155"))) {
+            return TokenStandard.ERC1155;
+        } else {
+            revert InvalidTokenStandard(standardString);
+        }
+    }
+}

--- a/scripts-foundry/common/DeployMagicDropImplementationDirect.s.sol
+++ b/scripts-foundry/common/DeployMagicDropImplementationDirect.s.sol
@@ -28,6 +28,7 @@ contract DeployMagicDropImplementationDirect is Script {
         address mintCurrency = address(0);
         address fundReceiver = address(uint160(vm.envUint("FUND_RECEIVER")));
         uint256 mintFee = vm.envUint("MINT_FEE");
+        address initialOwner = address(uint160(vm.envUint("INITIAL_OWNER")));
 
         vm.startBroadcast(privateKey);
 
@@ -45,7 +46,8 @@ contract DeployMagicDropImplementationDirect is Script {
                     timestampExpirySeconds,
                     mintCurrency,
                     fundReceiver,
-                    mintFee
+                    mintFee,
+                    initialOwner
                 ));
             } else {
                 revert NotImplementedYet();


### PR DESCRIPTION
We have a client request to deploy a launchpad contract with a vanity address, but we can't do this with our existing factory deployment flow:

The salt for the vanity address needs to be pre-computed with `forge create2`. However, when this salt is passed to `createContractDeterministic` it's re-hashed with `msg.sender` and `block.chainId`. Meaning, the salt will not be the same and the vanity address with not be achieved: https://github.com/me-foundation/magicdrop/blob/cd314bc3f1f62c96987faf399f0252a8d29cfd15/contracts/factory/MagicDropCloneFactory.sol#L122

These scripts directly deploy ERC721CM (non-initializable variant) directly using the pre-computed salt to achieve the vanity address via CREATE2.