### PR TITLE
Expose totalMinted

### DIFF
--- a/contracts/nft/creator-token-standards/ERC721ACQueryable.sol
+++ b/contracts/nft/creator-token-standards/ERC721ACQueryable.sol
@@ -42,6 +42,11 @@ abstract contract ERC721ACQueryable is ERC721AQueryable, CreatorTokenBase {
         }
     }
 
+    /// @dev Get the total minted count (including burned)
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     function _msgSenderERC721A() internal view virtual override returns (address) {
         return _msgSender();
     }

--- a/contracts/nft/creator-token-standards/ERC721ACQueryable.sol
+++ b/contracts/nft/creator-token-standards/ERC721ACQueryable.sol
@@ -43,6 +43,7 @@ abstract contract ERC721ACQueryable is ERC721AQueryable, CreatorTokenBase {
     }
 
     /// @dev Get the total minted count (including burned)
+    /// @return The total minted count
     function totalMinted() public view returns (uint256) {
         return _totalMinted();
     }

--- a/contracts/nft/creator-token-standards/ERC721ACQueryableInitializable.sol
+++ b/contracts/nft/creator-token-standards/ERC721ACQueryableInitializable.sol
@@ -83,6 +83,8 @@ abstract contract ERC721ACQueryableInitializable is
         }
     }
 
+    /// @dev Get the total minted count (including burned)
+    /// @return The total minted count
     function totalMinted() public view returns (uint256) {
         return _totalMinted();
     }

--- a/contracts/nft/erc721m/ERC721M.sol
+++ b/contracts/nft/erc721m/ERC721M.sol
@@ -209,6 +209,12 @@ contract ERC721M is
         return _numberMinted(a);
     }
 
+    /// @notice Get the total minted count (including burned)
+    /// @return The total minted count
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     /// @notice Gets the active stage from the timestamp
     /// @param timestamp The timestamp to get the active stage from
     /// @return The active stage

--- a/contracts/nft/erc721m/ERC721MInitializableV1_0_2.sol
+++ b/contracts/nft/erc721m/ERC721MInitializableV1_0_2.sol
@@ -276,6 +276,12 @@ contract ERC721MInitializableV1_0_2 is
         return _numberMinted(a);
     }
 
+    /// @notice Get the total minted count (including burned)
+    /// @return The total minted count
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     /// @notice Gets the active stage from the timestamp
     /// @param timestamp The timestamp to get the active stage from
     /// @return The active stage

--- a/contracts/nft/erc721m/clones/ERC721MagicDropMetadataCloneable.sol
+++ b/contracts/nft/erc721m/clones/ERC721MagicDropMetadataCloneable.sol
@@ -105,6 +105,12 @@ contract ERC721MagicDropMetadataCloneable is
         return _numberMinted(user);
     }
 
+    /// @notice Get the total minted count (including burned)
+    /// @return The total minted count
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     /// @notice Indicates whether this contract implements a given interface.
     /// @dev Supports ERC-2981 (royalties) and ERC-4906 (batch metadata updates), in addition to inherited interfaces.
     /// @param interfaceId The interface ID to check for compliance.

--- a/contracts/nft/erc721m/zksync/ERC721M.sol
+++ b/contracts/nft/erc721m/zksync/ERC721M.sol
@@ -210,6 +210,12 @@ contract ERC721M is
         return _numberMinted(a);
     }
 
+    /// @notice Get the total minted count (including burned)
+    /// @return The total minted count
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     /// @notice Gets the active stage from the timestamp
     /// @param timestamp The timestamp to get the active stage from
     /// @return The active stage

--- a/contracts/nft/erc721m/zksync/ERC721MInitializableV1_0_2.sol
+++ b/contracts/nft/erc721m/zksync/ERC721MInitializableV1_0_2.sol
@@ -277,6 +277,12 @@ contract ERC721MInitializableV1_0_2 is
         return _numberMinted(a);
     }
 
+    /// @notice Get the total minted count (including burned)
+    /// @return The total minted count
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     /// @notice Gets the active stage from the timestamp
     /// @param timestamp The timestamp to get the active stage from
     /// @return The active stage


### PR DESCRIPTION
Ensures `totalMinted` is exposed publicly on all 721 contracts that inherit 721A.