### PR TITLE
chore: move all cmds to network level

### DIFF
--- a/cli-typescript/src/cmds/createCommand.ts
+++ b/cli-typescript/src/cmds/createCommand.ts
@@ -6,19 +6,36 @@ import {
   getStagesFileOption,
   getTokenStandardOption,
   getTotalTokensOption,
-} from './cmdOptions';
-import { EvmPlatform } from './evmUtils';
-import deployAction from './cmdActions/deployAction';
-import { loadDefaults } from './loaders';
-import { setBaseDir } from './setters';
-import { showError } from './display';
+} from '../utils/cmdOptions';
+import { EvmPlatform } from '../utils/evmUtils';
+import deployAction from '../utils/cmdActions/deployAction';
+import { loadDefaults } from '../utils/loaders';
+import { setBaseDir } from '../utils/setters';
+import { showError } from '../utils/display';
 import {
   COLLECTION_DIR,
   supportedChainNames,
   TOKEN_STANDARD,
-} from './constants';
-import newProjectAction from './cmdActions/newProjectAction';
-import initContractAction from './cmdActions/initContractAction';
+} from '../utils/constants';
+import newProjectAction from '../utils/cmdActions/newProjectAction';
+import {
+  createNewWalletCmd,
+  freezeThawContractCmd,
+  initContractCmd,
+  listProjectsCmd,
+  manageAuthorizedMintersCmd,
+  ownerMintCmd,
+  setCosginerCmd,
+  setGlobalWalletLimitCmd,
+  setMaxMintableSupplyCmd,
+  setMintableCmd,
+  setStagesCmd,
+  setTimestampExpiryCmd,
+  setTokenURISuffixCmd,
+  setUriCmd,
+  transferOwnershipCmd,
+  withdrawContractBalanceCmd,
+} from './general';
 
 export const getNewProjectCmdDescription = (defaultInfo?: string) => {
   defaultInfo =
@@ -138,11 +155,22 @@ export const createEvmCommand = ({
       ) => await deployAction(platform, symbol, params),
     );
 
-  newCmd
-    .command('init-contract <collection>')
-    .description('Initialize/Set up a deployed collection (contract).')
-    .addOption(getStagesFileOption())
-    .action(initContractAction);
+  newCmd.addCommand(createNewWalletCmd);
+  newCmd.addCommand(listProjectsCmd);
+  newCmd.addCommand(initContractCmd);
+  newCmd.addCommand(setUriCmd);
+  newCmd.addCommand(setStagesCmd);
+  newCmd.addCommand(setGlobalWalletLimitCmd);
+  newCmd.addCommand(setMaxMintableSupplyCmd);
+  newCmd.addCommand(setCosginerCmd);
+  newCmd.addCommand(setTimestampExpiryCmd);
+  newCmd.addCommand(withdrawContractBalanceCmd);
+  newCmd.addCommand(freezeThawContractCmd);
+  newCmd.addCommand(transferOwnershipCmd);
+  newCmd.addCommand(manageAuthorizedMintersCmd);
+  newCmd.addCommand(setMintableCmd);
+  newCmd.addCommand(setTokenURISuffixCmd);
+  newCmd.addCommand(ownerMintCmd);
 
   return newCmd;
 };

--- a/cli-typescript/src/cmds/general.ts
+++ b/cli-typescript/src/cmds/general.ts
@@ -1,7 +1,5 @@
 import { Command } from 'commander';
-import newProjectAction from '../utils/cmdActions/newProjectAction';
 import {
-  getChainOption,
   getCosignerOption,
   getExpiryTimestampOption,
   getForceOption,
@@ -14,15 +12,12 @@ import {
   getNewOwnerOption,
   getQtyOption,
   getReceiverOption,
-  getSetupWalletOption,
   getStagesFileOption,
   getTokenIdOption,
-  getTokenStandardOption,
   getTokenUriSuffixOption,
   getUriOption,
 } from '../utils/cmdOptions';
 import listProjectsAction from '../utils/cmdActions/listProjectsAction';
-import { getNewProjectCmdDescription } from '../utils/createCommand';
 import newWalletAction from '../utils/cmdActions/newWalletAction';
 import setUriAction from '../utils/cmdActions/setUriAction';
 import initContractAction from '../utils/cmdActions/initContractAction';
@@ -40,15 +35,6 @@ import { setMintableAction } from '../utils/cmdActions/setMintableAction';
 import { setTokenUriSuffixAction } from '../utils/cmdActions/setTokenUriSuffixAction';
 import { ownerMintAction } from '../utils/cmdActions/ownerMintAction';
 import { checkSignerBalanceAction } from '../utils/cmdActions/checkSignerBalanceAction';
-
-export const newProjectCmd = new Command('new')
-  .command('new <symbol>')
-  .aliases(['n', 'init'])
-  .description(getNewProjectCmdDescription())
-  .addOption(getChainOption())
-  .addOption(getTokenStandardOption())
-  .addOption(getSetupWalletOption())
-  .action(newProjectAction);
 
 export const createNewWalletCmd = new Command('create-wallet')
   .command('create-wallet <symbol>')

--- a/cli-typescript/src/cmds/mainMenu.ts
+++ b/cli-typescript/src/cmds/mainMenu.ts
@@ -1,26 +1,6 @@
 import { Command } from 'commander';
 import { showMainTitle } from '../utils/display';
 import {
-  createNewWalletCmd,
-  freezeThawContractCmd,
-  checkSignerBalanceCmd,
-  initContractCmd,
-  listProjectsCmd,
-  manageAuthorizedMintersCmd,
-  newProjectCmd,
-  ownerMintCmd,
-  setCosginerCmd,
-  setGlobalWalletLimitCmd,
-  setMaxMintableSupplyCmd,
-  setMintableCmd,
-  setStagesCmd,
-  setTimestampExpiryCmd,
-  setTokenURISuffixCmd,
-  setUriCmd,
-  transferOwnershipCmd,
-  withdrawContractBalanceCmd,
-} from './general';
-import {
   abstract,
   apechain,
   arbitrum,
@@ -43,26 +23,6 @@ export const mainMenu = async () => {
     .name('magicdrop-cli')
     .description('CLI for managing blockchain contracts and tokens')
     .version('2.0.0');
-
-  // Register sub-commands
-  program.addCommand(newProjectCmd);
-  program.addCommand(createNewWalletCmd);
-  program.addCommand(listProjectsCmd);
-  program.addCommand(initContractCmd);
-  program.addCommand(setUriCmd);
-  program.addCommand(setStagesCmd);
-  program.addCommand(setGlobalWalletLimitCmd);
-  program.addCommand(setMaxMintableSupplyCmd);
-  program.addCommand(setCosginerCmd);
-  program.addCommand(setTimestampExpiryCmd);
-  program.addCommand(withdrawContractBalanceCmd);
-  program.addCommand(freezeThawContractCmd);
-  program.addCommand(transferOwnershipCmd);
-  program.addCommand(manageAuthorizedMintersCmd);
-  program.addCommand(setMintableCmd);
-  program.addCommand(setTokenURISuffixCmd);
-  program.addCommand(ownerMintCmd);
-  program.addCommand(checkSignerBalanceCmd);
 
   // network sub-commands
   program.addCommand(eth);

--- a/cli-typescript/src/cmds/networks/abstract.ts
+++ b/cli-typescript/src/cmds/networks/abstract.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/apechain.ts
+++ b/cli-typescript/src/cmds/networks/apechain.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/arbitrum.ts
+++ b/cli-typescript/src/cmds/networks/arbitrum.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/avalanche.ts
+++ b/cli-typescript/src/cmds/networks/avalanche.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/base.ts
+++ b/cli-typescript/src/cmds/networks/base.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/berachain.ts
+++ b/cli-typescript/src/cmds/networks/berachain.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/bsc.ts
+++ b/cli-typescript/src/cmds/networks/bsc.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/eth.ts
+++ b/cli-typescript/src/cmds/networks/eth.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/monad.ts
+++ b/cli-typescript/src/cmds/networks/monad.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/polygon.ts
+++ b/cli-typescript/src/cmds/networks/polygon.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 

--- a/cli-typescript/src/cmds/networks/sei.ts
+++ b/cli-typescript/src/cmds/networks/sei.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_CHAINS } from '../../utils/constants';
-import { createEvmCommand } from '../../utils/createCommand';
+import { createEvmCommand } from '../createCommand';
 import { EvmPlatform } from '../../utils/evmUtils';
 import { getSymbolFromChainId } from '../../utils/getters';
 


### PR DESCRIPTION
Move all sub-cmds to network level

For example:

`drop2 create-wallet <symbol>`

Is now

`drop2 eth create-wallet <symbol>`

This follows the `contract-works` pattern and will enable easy integration.